### PR TITLE
Since ONe 3.2 the password dont need to be hashed anymore.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -11,7 +11,7 @@ Bindings for XMLRPC OpenNebula Cloud API
 
 Documentation
 -------------
-see http://lukaszo.github.com/python-oca/index.html and http://www.opennebula.org/documentation:rel3.0:api
+see http://lukaszo.github.com/python-oca/index.html and http://www.opennebula.org/documentation:rel3.2:api
 
 All `allocate` functions are implemented as static methods.
 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -1,7 +1,7 @@
 API Documentation
 =================
 
-See http://www.opennebula.org/documentation:rel3.0:api
+See http://www.opennebula.org/documentation:rel3.2:api
 
 .. toctree::
    :maxdepth: 2

--- a/oca/__init__.py
+++ b/oca/__init__.py
@@ -49,7 +49,7 @@ class ProxiedTransport(xmlrpclib.Transport):
 class Client(object):
     '''
     The client class, represents the connection with the core and handles the
-    xml-rpc calls(see http://www.opennebula.org/documentation:rel3.0:api)
+    xml-rpc calls(see http://www.opennebula.org/documentation:rel3.2:api)
     '''
     DEFAULT_ONE_AUTH = "~/.one/one_auth"
     ONE_AUTH_RE = re.compile('^(.+?):(.+)$')
@@ -75,10 +75,6 @@ class Client(object):
         else:
             raise OpenNebulaException("Authorization file malformed")
 
-        if password.startswith('plain:'):
-            password = password.split(':', 1)[1]
-        else:
-            password = hashlib.sha1(password).hexdigest()
         self.one_auth = '{0}:{1}'.format(user, password)
 
         if address:


### PR DESCRIPTION
Hi Łukasz,

this patch changes the way the password credentials are handled as since OpenNebula 3.2 the XML-RPC  clients don't need to hash the password from the one_auth file.
See:   http://archives.opennebula.org/documentation:archives:rel3.2:compatibility#developers_and_integrators

This breaks the compatibility to OpenNebula 3.0. 

Best wishes,
Matthias
